### PR TITLE
Issue #242 Have MGCP Endpoint aware of its domain

### DIFF
--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/mgcp/MgcpEndpointInstallerProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/mgcp/MgcpEndpointInstallerProvider.java
@@ -64,7 +64,8 @@ public class MgcpEndpointInstallerProvider implements Provider<List<MgcpEndpoint
         final MgcpControllerConfiguration controller = this.configuration.getControllerConfiguration();
         final Iterator<MgcpEndpointConfiguration> iterator = controller.getEndpoints();
         final List<MgcpEndpointProvider<? extends MgcpEndpoint>> providers = new ArrayList<>(controller.countEndpoints());
-
+        final String domain = this.configuration.getControllerConfiguration().getAddress();
+        
         while (iterator.hasNext()) {
             final MgcpEndpointConfiguration endpoint = iterator.next();
             final MgcpEndpointProvider<? extends MgcpEndpoint> provider;
@@ -72,11 +73,11 @@ public class MgcpEndpointInstallerProvider implements Provider<List<MgcpEndpoint
 
             switch (endpoint.getRelayType()) {
                 case MIXER:
-                    provider = new MgcpMixerEndpointProvider(namespace, this.mediaScheduler, this.connectionProvider, this.MediaGroupProvider);
+                    provider = new MgcpMixerEndpointProvider(namespace, domain, this.mediaScheduler, this.connectionProvider, this.MediaGroupProvider);
                     break;
 
                 case SPLITTER:
-                    provider = new MgcpSplitterEndpointProvider(namespace, this.mediaScheduler, this.connectionProvider, this.MediaGroupProvider);
+                    provider = new MgcpSplitterEndpointProvider(namespace, domain, this.mediaScheduler, this.connectionProvider, this.MediaGroupProvider);
                     break;
 
                 default:

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/command/CreateConnectionCommand.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/command/CreateConnectionCommand.java
@@ -118,10 +118,10 @@ public class CreateConnectionCommand extends AbstractMgcpCommand {
         final int indexOfAll = endpointId.indexOf(WILDCARD_ANY);
         if (indexOfAll == -1) {
             // Search for registered endpoint
-            endpoint = this.endpointManager.getEndpoint(localName);
+            endpoint = this.endpointManager.getEndpoint(endpointId);
 
             if (endpoint == null) {
-                throw new MgcpCommandException(MgcpResponseCode.ENDPOINT_NOT_AVAILABLE);
+                throw new MgcpCommandException(MgcpResponseCode.ENDPOINT_UNKNOWN);
             }
         } else {
             // Create new endpoint for a specific name space
@@ -222,9 +222,9 @@ public class CreateConnectionCommand extends AbstractMgcpCommand {
         final MgcpEndpoint endpoint2 = secondEndpointId.isEmpty() ? null : retrieveEndpoint(secondEndpointId);
         
         // Update context with endpoint ID (in case they new endpoints were created)
-        context.setEndpointId(endpoint1.getEndpointId());
+        context.setEndpointId(endpoint1.getEndpointId().toString());
         if(endpoint2 != null) {
-            context.setSecondEndpointId(endpoint2.getEndpointId());
+            context.setSecondEndpointId(endpoint2.getEndpointId().toString());
         }
 
         // Create Connections

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/EndpointIdentifier.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/EndpointIdentifier.java
@@ -27,14 +27,14 @@ package org.mobicents.media.control.mgcp.endpoint;
  * @author Henrique Rosa (henrique.rosa@telestax.com)
  *
  */
-public class MgcpEndpointName {
+public class EndpointIdentifier {
 
     private static final String SEPARATOR = "@";
 
     private final String localName;
     private final String domainName;
 
-    public MgcpEndpointName(String localName, String domainName) {
+    public EndpointIdentifier(String localName, String domainName) {
         this.localName = localName;
         this.domainName = domainName;
     }

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/EndpointIdentifierParser.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/EndpointIdentifierParser.java
@@ -19,35 +19,33 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.mobicents.media.control.mgcp.endpoint.provider;
-
-import org.mobicents.media.control.mgcp.endpoint.MgcpEndpoint;
+package org.mobicents.media.control.mgcp.endpoint;
 
 /**
+ * Parses identifiers of MGCP Endpoints.
+ * 
+ * <p>
+ * Endpoint identifiers have the format [localName]@[domain].
+ * </p>
+ * 
  * @author Henrique Rosa (henrique.rosa@telestax.com)
  *
  */
-public interface MgcpEndpointProvider<T extends MgcpEndpoint> {
+public class EndpointIdentifierParser {
 
-    /**
-     * Gets the name space associated with the provided endpoints.
-     * 
-     * @return The name space.
-     */
-    String getNamespace();
+    private static final String SEPARATOR = "@";
 
-    /**
-     * Gets the domain of the media gateway.
-     * 
-     * @return The domain of the media gateway
-     */
-    String getDomain();
+    public static EndpointIdentifier parse(String identifier) throws IllegalArgumentException {
+        // Validate identifier
+        int index = identifier.indexOf(SEPARATOR);
+        if (index <= 0) {
+            throw new IllegalArgumentException("The endpoint identifier " + identifier +" is malformed.");
+        }
 
-    /**
-     * Provides a new endpoint.
-     * 
-     * @return The newly created endpoint
-     */
-    T provide();
+        // Parse and return identifier object
+        String localName = identifier.substring(0, index);
+        String domain = identifier.substring(index + 1);
+        return new EndpointIdentifier(localName, domain);
+    }
 
 }

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/GenericMgcpEndpoint.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/GenericMgcpEndpoint.java
@@ -65,7 +65,7 @@ public class GenericMgcpEndpoint implements MgcpEndpoint, MgcpCallListener, Mgcp
     protected final MediaGroup mediaGroup;
 
     // Endpoint Properties
-    private final String endpointId;
+    private final EndpointIdentifier endpointId;
     private final NotifiedEntity defaultNotifiedEntity;
     private final ConcurrentHashMap<Integer, MgcpCall> calls;
 
@@ -80,7 +80,7 @@ public class GenericMgcpEndpoint implements MgcpEndpoint, MgcpCallListener, Mgcp
     private final Collection<MgcpEndpointObserver> endpointObservers;
     private final Collection<MgcpMessageObserver> messageObservers;
 
-    public GenericMgcpEndpoint(String endpointId, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
+    public GenericMgcpEndpoint(EndpointIdentifier endpointId, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
         // MGCP Components
         this.connectionProvider = connectionProvider;
 
@@ -101,7 +101,7 @@ public class GenericMgcpEndpoint implements MgcpEndpoint, MgcpCallListener, Mgcp
     }
 
     @Override
-    public String getEndpointId() {
+    public EndpointIdentifier getEndpointId() {
         return this.endpointId;
     }
 
@@ -396,7 +396,7 @@ public class GenericMgcpEndpoint implements MgcpEndpoint, MgcpCallListener, Mgcp
             MgcpRequest notify = new MgcpRequest();
             notify.setRequestType(MgcpRequestType.NTFY);
             notify.setTransactionId(0);
-            notify.setEndpointId(this.endpointId);
+            notify.setEndpointId(this.endpointId.toString());
             notify.addParameter(MgcpParameterType.NOTIFIED_ENTITY, resolve(this.notificationRequest.getNotifiedEntity(), this.defaultNotifiedEntity).toString());
             notify.addParameter(MgcpParameterType.OBSERVED_EVENT, event.toString());
             notify.addParameter(MgcpParameterType.REQUEST_ID, notificationRequest.getRequestIdentifier());

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MalformedMgcpEndpointIdentifier.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MalformedMgcpEndpointIdentifier.java
@@ -19,35 +19,26 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.mobicents.media.control.mgcp.endpoint.provider;
+package org.mobicents.media.control.mgcp.endpoint;
 
-import org.mobicents.media.control.mgcp.endpoint.MgcpEndpoint;
+import org.mobicents.media.control.mgcp.exception.MgcpEndpointException;
 
 /**
+ * Thrown when an MGCP Endpoint Identifier is malformed.
+ * 
  * @author Henrique Rosa (henrique.rosa@telestax.com)
  *
  */
-public interface MgcpEndpointProvider<T extends MgcpEndpoint> {
+public class MalformedMgcpEndpointIdentifier extends MgcpEndpointException {
 
-    /**
-     * Gets the name space associated with the provided endpoints.
-     * 
-     * @return The name space.
-     */
-    String getNamespace();
+    private static final long serialVersionUID = -5090718013826757327L;
 
-    /**
-     * Gets the domain of the media gateway.
-     * 
-     * @return The domain of the media gateway
-     */
-    String getDomain();
+    public MalformedMgcpEndpointIdentifier(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-    /**
-     * Provides a new endpoint.
-     * 
-     * @return The newly created endpoint
-     */
-    T provide();
+    public MalformedMgcpEndpointIdentifier(String message) {
+        super(message);
+    }
 
 }

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpoint.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpoint.java
@@ -52,7 +52,7 @@ public interface MgcpEndpoint extends MgcpEndpointSubject, MgcpMessageSubject, M
      * 
      * @return The endpoint ID
      */
-    String getEndpointId();
+    EndpointIdentifier getEndpointId();
 
     /**
      * Gets a connection by identifier.

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpointManager.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpointManager.java
@@ -90,7 +90,7 @@ public class MgcpEndpointManager implements MgcpEndpointObserver, MgcpMessageObs
         MgcpEndpoint endpoint = provider.provide();
         endpoint.observe((MgcpEndpointObserver) this);
         endpoint.observe((MgcpMessageObserver) this);
-        this.endpoints.put(endpoint.getEndpointId(), endpoint);
+        this.endpoints.put(endpoint.getEndpointId().toString(), endpoint);
         return endpoint;
     }
 
@@ -101,8 +101,7 @@ public class MgcpEndpointManager implements MgcpEndpointObserver, MgcpMessageObs
      * @return The endpoint if registered; otherwise returns null
      */
     public MgcpEndpoint getEndpoint(String endpointId) {
-        String localName = resolveEndpointId(endpointId);
-        return this.endpoints.get(localName);
+        return this.endpoints.get(endpointId);
     }
 
     /**
@@ -112,23 +111,12 @@ public class MgcpEndpointManager implements MgcpEndpointObserver, MgcpMessageObs
      * @throws MgcpEndpointNotFoundException If there is no registered endpoint with such ID
      */
     public void unregisterEndpoint(String endpointId) throws MgcpEndpointNotFoundException {
-        String localName = resolveEndpointId(endpointId);
-        MgcpEndpoint endpoint = this.endpoints.remove(localName);
+        MgcpEndpoint endpoint = this.endpoints.remove(endpointId);
         if (endpoint == null) {
             throw new MgcpEndpointNotFoundException("Endpoint " + endpointId + " not found");
         }
         endpoint.forget((MgcpMessageObserver) this);
         endpoint.forget((MgcpEndpointObserver) this);
-    }
-
-    // FIXME Right now only deals with localName. Should take domain into account in the future.
-    private String resolveEndpointId(String endpointId) {
-        String result = endpointId;
-        int indexOfSeparator = endpointId.indexOf("@");
-        if (indexOfSeparator > -1) {
-            result = endpointId.substring(0, indexOfSeparator);
-        }
-        return result;
     }
 
     @Override

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpMixerEndpoint.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpMixerEndpoint.java
@@ -38,7 +38,7 @@ public class MgcpMixerEndpoint extends GenericMgcpEndpoint {
     private final AudioMixer inbandMixer;
     private final OOBMixer outbandMixer;
 
-    public MgcpMixerEndpoint(String endpointId, AudioMixer inbandMixer, OOBMixer outbandMixer, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
+    public MgcpMixerEndpoint(EndpointIdentifier endpointId, AudioMixer inbandMixer, OOBMixer outbandMixer, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
         super(endpointId, connectionProvider, mediaGroup);
         this.inbandMixer = inbandMixer;
         this.outbandMixer = outbandMixer;

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpoint.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpoint.java
@@ -37,7 +37,7 @@ public class MgcpSplitterEndpoint extends GenericMgcpEndpoint {
     private final AudioSplitter inbandSplitter;
     private final OOBSplitter outbandSplitter;
 
-    public MgcpSplitterEndpoint(String endpointId, AudioSplitter inbandSplitter, OOBSplitter outbandSplitter, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
+    public MgcpSplitterEndpoint(EndpointIdentifier endpointId, AudioSplitter inbandSplitter, OOBSplitter outbandSplitter, MgcpConnectionProvider connectionProvider, MediaGroup mediaGroup) {
         super(endpointId, connectionProvider, mediaGroup);
         this.inbandSplitter = inbandSplitter;
         this.outbandSplitter = outbandSplitter;

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/AbstractMgcpEndpointProvider.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/AbstractMgcpEndpointProvider.java
@@ -34,10 +34,12 @@ import org.mobicents.media.control.mgcp.endpoint.MgcpEndpoint;
 public abstract class AbstractMgcpEndpointProvider<T extends MgcpEndpoint> implements MgcpEndpointProvider<T> {
     
     private final String namespace;
+    private final String domain;
     private final AtomicInteger idGenerator;
     
-    public AbstractMgcpEndpointProvider(String namespace) {
+    public AbstractMgcpEndpointProvider(String namespace, String domain) {
         this.namespace = namespace;
+        this.domain = domain;
         this.idGenerator = new AtomicInteger(0);
     }
 
@@ -46,8 +48,18 @@ public abstract class AbstractMgcpEndpointProvider<T extends MgcpEndpoint> imple
         return this.namespace;
     }
     
+    @Override
+    public String getDomain() {
+        return this.domain;
+    }
+    
     protected String generateId() {
-        return this.namespace + this.idGenerator.incrementAndGet();
+        return this.namespace + nextId();
+    }
+    
+    private int nextId() {
+        this.idGenerator.compareAndSet(Integer.MAX_VALUE, 0);
+        return this.idGenerator.incrementAndGet();
     }
 
 }

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/MgcpMixerEndpointProvider.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/MgcpMixerEndpointProvider.java
@@ -22,6 +22,7 @@
 package org.mobicents.media.control.mgcp.endpoint.provider;
 
 import org.mobicents.media.control.mgcp.connection.MgcpConnectionProvider;
+import org.mobicents.media.control.mgcp.endpoint.EndpointIdentifier;
 import org.mobicents.media.control.mgcp.endpoint.MediaGroup;
 import org.mobicents.media.control.mgcp.endpoint.MgcpMixerEndpoint;
 import org.mobicents.media.server.component.audio.AudioMixer;
@@ -40,8 +41,8 @@ public class MgcpMixerEndpointProvider extends AbstractMgcpEndpointProvider<Mgcp
     private final MgcpConnectionProvider connectionProvider;
     private final MediaGroupProvider mediaGroupProvider;
 
-    public MgcpMixerEndpointProvider(String namespace, PriorityQueueScheduler mediaScheduler, MgcpConnectionProvider connectionProvider, MediaGroupProvider mediaGroupProvider) {
-        super(namespace);
+    public MgcpMixerEndpointProvider(String namespace, String domain, PriorityQueueScheduler mediaScheduler, MgcpConnectionProvider connectionProvider, MediaGroupProvider mediaGroupProvider) {
+        super(namespace, domain);
         this.mediaScheduler = mediaScheduler;
         this.connectionProvider = connectionProvider;
         this.mediaGroupProvider = mediaGroupProvider;
@@ -49,7 +50,7 @@ public class MgcpMixerEndpointProvider extends AbstractMgcpEndpointProvider<Mgcp
 
     @Override
     public MgcpMixerEndpoint provide() {
-        final String endpointId = generateId();
+        final EndpointIdentifier endpointId = new EndpointIdentifier(generateId(), getDomain());
         final AudioMixer audioMixer = new AudioMixer(this.mediaScheduler);
         final OOBMixer oobMixer = new OOBMixer(this.mediaScheduler);
         final MediaGroup mediaGroup = this.mediaGroupProvider.provide();

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/MgcpSplitterEndpointProvider.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/endpoint/provider/MgcpSplitterEndpointProvider.java
@@ -22,6 +22,7 @@
 package org.mobicents.media.control.mgcp.endpoint.provider;
 
 import org.mobicents.media.control.mgcp.connection.MgcpConnectionProvider;
+import org.mobicents.media.control.mgcp.endpoint.EndpointIdentifier;
 import org.mobicents.media.control.mgcp.endpoint.MediaGroup;
 import org.mobicents.media.control.mgcp.endpoint.MgcpSplitterEndpoint;
 import org.mobicents.media.server.component.audio.AudioSplitter;
@@ -40,8 +41,8 @@ public class MgcpSplitterEndpointProvider extends AbstractMgcpEndpointProvider<M
     private final MgcpConnectionProvider connectionProvider;
     private final MediaGroupProvider mediaGroupProvider;
 
-    public MgcpSplitterEndpointProvider(String namespace, PriorityQueueScheduler mediaScheduler, MgcpConnectionProvider connectionProvider, MediaGroupProvider mediaGroupProvider) {
-        super(namespace);
+    public MgcpSplitterEndpointProvider(String namespace, String domain, PriorityQueueScheduler mediaScheduler, MgcpConnectionProvider connectionProvider, MediaGroupProvider mediaGroupProvider) {
+        super(namespace, domain);
         this.mediaScheduler = mediaScheduler;
         this.connectionProvider = connectionProvider;
         this.mediaGroupProvider = mediaGroupProvider;
@@ -49,7 +50,7 @@ public class MgcpSplitterEndpointProvider extends AbstractMgcpEndpointProvider<M
 
     @Override
     public MgcpSplitterEndpoint provide() {
-        final String endpointId = generateId();
+        final EndpointIdentifier endpointId = new EndpointIdentifier(generateId(), getDomain());
         final AudioSplitter audioSplitter = new AudioSplitter(this.mediaScheduler);
         final OOBSplitter oobSplitter = new OOBSplitter(this.mediaScheduler);
         final MediaGroup mediaGroup = this.mediaGroupProvider.provide();

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/message/MgcpRequest.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/message/MgcpRequest.java
@@ -78,7 +78,7 @@ public class MgcpRequest extends MgcpMessage {
         // Build header
         this.builder.append(this.requestType.name()).append(" ")
                 .append(this.transactionId).append(" ")
-                .append(getEndpointId()).append("@127.0.0.1:2427").append(" ")
+                .append(getEndpointId()).append(" ")
                 .append(VERSION).append(System.lineSeparator());
 
         // Build parameters

--- a/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/message/MgcpResponse.java
+++ b/controls/mgcp2/src/main/java/org/mobicents/media/control/mgcp/message/MgcpResponse.java
@@ -23,7 +23,6 @@ package org.mobicents.media.control.mgcp.message;
 
 import java.util.Iterator;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
 /**
@@ -90,21 +89,7 @@ public class MgcpResponse extends MgcpMessage {
             MgcpParameterType key = iterator.next();
             Optional<String> value = parameters.getString(key);
             if(value.isPresent() && !key.equals(MgcpParameterType.SDP)) {
-                String effectiveValue;
-                // XXX HACKING endpoint domain name
-                if(MgcpParameterType.ENDPOINT_ID.equals(key) || MgcpParameterType.SECOND_ENDPOINT.equals(key)) {
-                    effectiveValue = value.transform(new Function<String, String>() {
-
-                        @Override
-                        public String apply(String input) {
-                            return input + "@127.0.0.1:2427";
-                        }
-                        
-                    }).get();
-                } else {
-                    effectiveValue = value.get();
-                }
-                builder.append(System.lineSeparator()).append(key.getCode()).append(":").append(effectiveValue);
+                builder.append(System.lineSeparator()).append(key.getCode()).append(":").append(value.get());
             }
         }
 

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/command/CreateConnectionCommandTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/command/CreateConnectionCommandTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.mobicents.media.control.mgcp.connection.MgcpConnectionProvider;
 import org.mobicents.media.control.mgcp.connection.MgcpLocalConnection;
 import org.mobicents.media.control.mgcp.connection.MgcpRemoteConnection;
+import org.mobicents.media.control.mgcp.endpoint.EndpointIdentifier;
 import org.mobicents.media.control.mgcp.endpoint.MgcpEndpoint;
 import org.mobicents.media.control.mgcp.endpoint.MgcpEndpointManager;
 import org.mobicents.media.control.mgcp.exception.MgcpConnectionException;
@@ -70,6 +71,8 @@ public class CreateConnectionCommandTest {
         final MgcpEndpoint ivrEndpoint = mock(MgcpEndpoint.class);
         final MgcpLocalConnection connection1 = mock(MgcpLocalConnection.class);
         final MgcpLocalConnection connection2 = mock(MgcpLocalConnection.class);
+        final EndpointIdentifier bridgeEndpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
+        final EndpointIdentifier ivrEndpointId = new EndpointIdentifier("mobicents/ivr/1", "127.0.0.1:2427");
         final CreateConnectionCommand crcx = new CreateConnectionCommand(transactionId, request.getParameters(), endpointManager);
 
         // when
@@ -78,8 +81,8 @@ public class CreateConnectionCommandTest {
         when(connection2.getIdentifier()).thenReturn(2);
         when(endpointManager.registerEndpoint("mobicents/bridge/")).thenReturn(bridgeEndpoint);
         when(endpointManager.registerEndpoint("mobicents/ivr/")).thenReturn(ivrEndpoint);
-        when(bridgeEndpoint.getEndpointId()).thenReturn("mobicents/bridge/1");
-        when(ivrEndpoint.getEndpointId()).thenReturn("mobicents/ivr/2");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(bridgeEndpointId);
+        when(ivrEndpoint.getEndpointId()).thenReturn(ivrEndpointId);
         when(bridgeEndpoint.createConnection(1, true)).thenReturn(connection1);
         when(ivrEndpoint.createConnection(1, true)).thenReturn(connection2);
 
@@ -97,8 +100,8 @@ public class CreateConnectionCommandTest {
         
         Parameters<MgcpParameterType> parameters = result.getParameters();
         assertEquals(4, result.getParameters().size());
-        assertEquals(bridgeEndpoint.getEndpointId(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
-        assertEquals(ivrEndpoint.getEndpointId(), parameters.getString(MgcpParameterType.SECOND_ENDPOINT).or(""));
+        assertEquals(bridgeEndpoint.getEndpointId().toString(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
+        assertEquals(ivrEndpoint.getEndpointId().toString(), parameters.getString(MgcpParameterType.SECOND_ENDPOINT).or(""));
         assertEquals(connection1.getIdentifier(), parameters.getInteger(MgcpParameterType.CONNECTION_ID).or(0).intValue());
         assertEquals(connection2.getIdentifier(), parameters.getInteger(MgcpParameterType.CONNECTION_ID2).or(0).intValue());
     }
@@ -118,6 +121,7 @@ public class CreateConnectionCommandTest {
         final MgcpEndpointManager endpointManager = mock(MgcpEndpointManager.class);
         final MgcpConnectionProvider connectionProvider = mock(MgcpConnectionProvider.class);
         final MgcpEndpoint bridgeEndpoint = mock(MgcpEndpoint.class);
+        final EndpointIdentifier bridgeEndpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
         final MgcpRemoteConnection connection = mock(MgcpRemoteConnection.class);
         final CreateConnectionCommand crcx = new CreateConnectionCommand(transactionId, request.getParameters(), endpointManager);
 
@@ -126,7 +130,7 @@ public class CreateConnectionCommandTest {
         when(connection.halfOpen(any(LocalConnectionOptions.class))).thenReturn("answer");
         when(connectionProvider.provideRemote()).thenReturn(connection);
         when(endpointManager.registerEndpoint("mobicents/bridge/")).thenReturn(bridgeEndpoint);
-        when(bridgeEndpoint.getEndpointId()).thenReturn("mobicents/bridge/1");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(bridgeEndpointId);
         when(bridgeEndpoint.createConnection(1, false)).thenReturn(connection);
 
         MgcpCommandResult result = crcx.call();
@@ -141,7 +145,7 @@ public class CreateConnectionCommandTest {
 
         Parameters<MgcpParameterType> parameters = result.getParameters();
         assertEquals(3, result.getParameters().size());
-        assertEquals(bridgeEndpoint.getEndpointId(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
+        assertEquals(bridgeEndpoint.getEndpointId().toString(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
         assertEquals(connection.getIdentifier(), parameters.getInteger(MgcpParameterType.CONNECTION_ID).or(0).intValue());
         assertEquals("answer", parameters.getString(MgcpParameterType.SDP).or(""));
     }
@@ -171,6 +175,7 @@ public class CreateConnectionCommandTest {
         final MgcpEndpointManager endpointManager = mock(MgcpEndpointManager.class);
         final MgcpConnectionProvider connectionProvider = mock(MgcpConnectionProvider.class);
         final MgcpEndpoint bridgeEndpoint = mock(MgcpEndpoint.class);
+        final EndpointIdentifier bridgeEndpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
         final MgcpRemoteConnection connection = mock(MgcpRemoteConnection.class);
         final CreateConnectionCommand crcx = new CreateConnectionCommand(transactionId, request.getParameters(), endpointManager);
 
@@ -179,7 +184,7 @@ public class CreateConnectionCommandTest {
         when(connection.getIdentifier()).thenReturn(1);
         when(connection.open(builderSdp.toString())).thenReturn("answer");
         when(endpointManager.registerEndpoint("mobicents/bridge/")).thenReturn(bridgeEndpoint);
-        when(bridgeEndpoint.getEndpointId()).thenReturn("mobicents/bridge/1");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(bridgeEndpointId);
         when(bridgeEndpoint.createConnection(1, false)).thenReturn(connection);
 
         MgcpCommandResult result = crcx.call();
@@ -195,7 +200,7 @@ public class CreateConnectionCommandTest {
 
         Parameters<MgcpParameterType> parameters = result.getParameters();
         assertEquals(3, result.getParameters().size());
-        assertEquals(bridgeEndpoint.getEndpointId(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
+        assertEquals(bridgeEndpoint.getEndpointId().toString(), parameters.getString(MgcpParameterType.ENDPOINT_ID).or(""));
         assertEquals(connection.getIdentifier(), parameters.getInteger(MgcpParameterType.CONNECTION_ID).or(0).intValue());
         assertEquals("answer", parameters.getString(MgcpParameterType.SDP).or(""));
     }
@@ -370,12 +375,13 @@ public class CreateConnectionCommandTest {
         final MgcpRequest request = new MgcpMessageParser().parseRequest(builder.toString());
         final MgcpEndpointManager endpointManager = mock(MgcpEndpointManager.class);
         final MgcpEndpoint bridgeEndpoint = mock(MgcpEndpoint.class);
+        final EndpointIdentifier bridgeEndpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
         final CreateConnectionCommand crcx = new CreateConnectionCommand(transactionId, request.getParameters(), endpointManager);
 
         // when
         when(endpointManager.registerEndpoint("mobicents/bridge/")).thenReturn(bridgeEndpoint);
         when(endpointManager.registerEndpoint("mobicents/ivr/")).thenThrow(new UnrecognizedMgcpNamespaceException(""));
-        when(bridgeEndpoint.getEndpointId()).thenReturn("mobicents/bridge/1");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(bridgeEndpointId);
 
         MgcpCommandResult result = crcx.call();
 
@@ -401,6 +407,8 @@ public class CreateConnectionCommandTest {
         final MgcpConnectionProvider connectionProvider = mock(MgcpConnectionProvider.class);
         final MgcpEndpoint bridgeEndpoint = mock(MgcpEndpoint.class);
         final MgcpEndpoint ivrEndpoint = mock(MgcpEndpoint.class);
+        final EndpointIdentifier bridgeEndpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
+        final EndpointIdentifier ivrEndpointId = new EndpointIdentifier("mobicents/ivr/2", "127.0.0.1:2427");
         final MgcpLocalConnection connection1 = mock(MgcpLocalConnection.class);
         final MgcpLocalConnection connection2 = mock(MgcpLocalConnection.class);
         final CreateConnectionCommand crcx = new CreateConnectionCommand(transactionId, request.getParameters(), endpointManager);
@@ -411,12 +419,12 @@ public class CreateConnectionCommandTest {
         when(connection1.getHexIdentifier()).thenReturn(Integer.toHexString(1));
         when(connection2.getIdentifier()).thenReturn(2);
         when(connection2.getHexIdentifier()).thenReturn(Integer.toHexString(1));
-        when(bridgeEndpoint.getEndpointId()).thenReturn("mobicents/bridge/1");
-        when(ivrEndpoint.getEndpointId()).thenReturn("mobicents/ivr/2");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(bridgeEndpointId);
+        when(ivrEndpoint.getEndpointId()).thenReturn(ivrEndpointId);
         when(endpointManager.registerEndpoint("mobicents/bridge/")).thenReturn(bridgeEndpoint);
         when(endpointManager.registerEndpoint("mobicents/ivr/")).thenReturn(ivrEndpoint);
-        when(endpointManager.getEndpoint(bridgeEndpoint.getEndpointId())).thenReturn(bridgeEndpoint);
-        when(endpointManager.getEndpoint(ivrEndpoint.getEndpointId())).thenReturn(ivrEndpoint);
+        when(endpointManager.getEndpoint(bridgeEndpoint.getEndpointId().toString())).thenReturn(bridgeEndpoint);
+        when(endpointManager.getEndpoint(ivrEndpoint.getEndpointId().toString())).thenReturn(ivrEndpoint);
         when(bridgeEndpoint.createConnection(1, true)).thenReturn(connection1);
         when(ivrEndpoint.createConnection(1, true)).thenReturn(connection2);
 

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/GenericMgcpEndpointTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/GenericMgcpEndpointTest.java
@@ -52,7 +52,8 @@ public class GenericMgcpEndpointTest {
         final NotificationRequest rqnt = new NotificationRequest(1, "1a", notifiedEntity, requestedEvents, signal);
         final MgcpConnectionProvider connectionProvider = mock(MgcpConnectionProvider.class);
         final MediaGroup mediaGroup = mock(MediaGroup.class);
-        final MgcpEndpoint genericMgcpEndpoint = new GenericMgcpEndpoint("mobicents/endpoint/1", connectionProvider, mediaGroup);
+        final EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/endpoint/1", "127.0.0.1:2427");
+        final MgcpEndpoint genericMgcpEndpoint = new GenericMgcpEndpoint(endpointId, connectionProvider, mediaGroup);
 
         // when
         genericMgcpEndpoint.requestNotification(rqnt);
@@ -72,7 +73,8 @@ public class GenericMgcpEndpointTest {
         final NotificationRequest rqnt2 = new NotificationRequest(2, "1b", notifiedEntity, requestedEvents, signal2);
         final MgcpConnectionProvider connectionProvider = mock(MgcpConnectionProvider.class);
         final MediaGroup mediaGroup = mock(MediaGroup.class);
-        final MgcpEndpoint genericMgcpEndpoint = new GenericMgcpEndpoint("mobicents/endpoint/1", connectionProvider, mediaGroup);
+        final EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/endpoint/1", "127.0.0.1:2427");
+        final MgcpEndpoint genericMgcpEndpoint = new GenericMgcpEndpoint(endpointId, connectionProvider, mediaGroup);
 
         // when
         genericMgcpEndpoint.requestNotification(rqnt1);

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpointManagerTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpEndpointManagerTest.java
@@ -105,27 +105,29 @@ public class MgcpEndpointManagerTest {
         // given
         MgcpEndpointManager endpointManager = new MgcpEndpointManager();
         MgcpEndpoint bridgeEndpoint = mock(MgcpEndpoint.class);
+        EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/bridge/1", "127.0.0.1:2427");
         AbstractMgcpEndpointProvider<MgcpEndpoint> bridgeProvider = mock(AbstractMgcpEndpointProvider.class);
 
         // when
         when(bridgeProvider.getNamespace()).thenReturn(NAMESPACE_BRIDGE);
+        when(bridgeProvider.getDomain()).thenReturn("127.0.0.1:2427");
         when(bridgeProvider.provide()).thenReturn(bridgeEndpoint);
-        when(bridgeEndpoint.getEndpointId()).thenReturn(NAMESPACE_BRIDGE + "1");
+        when(bridgeEndpoint.getEndpointId()).thenReturn(endpointId);
 
         endpointManager.installProvider(bridgeProvider);
         MgcpEndpoint endpoint = endpointManager.registerEndpoint(NAMESPACE_BRIDGE);
 
         // then
         assertEquals(bridgeEndpoint, endpoint);
-        assertEquals(bridgeEndpoint, endpointManager.getEndpoint(bridgeEndpoint.getEndpointId()));
+        assertEquals(bridgeEndpoint, endpointManager.getEndpoint(bridgeEndpoint.getEndpointId().toString()));
         // TODO Fix me!!
 //        verify(bridgeEndpoint, times(1)).observe(endpointManager);
 
         // when
-        endpointManager.unregisterEndpoint(bridgeEndpoint.getEndpointId());
+        endpointManager.unregisterEndpoint(bridgeEndpoint.getEndpointId().toString());
 
         // then
-        assertNull(endpointManager.getEndpoint(bridgeEndpoint.getEndpointId()));
+        assertNull(endpointManager.getEndpoint(bridgeEndpoint.getEndpointId().toString()));
         // TODO Fix me!!
 //        verify(bridgeEndpoint, times(1)).forget(endpointManager);
     }

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpMixerEndpointTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpMixerEndpointTest.java
@@ -50,7 +50,8 @@ public class MgcpMixerEndpointTest {
         final OOBMixer outbandMixer = mock(OOBMixer.class);
         final MgcpConnectionProvider connections = mock(MgcpConnectionProvider.class);
         final MediaGroup mediaGroup = mock(MediaGroupImpl.class);
-        final MgcpMixerEndpoint endpoint = new MgcpMixerEndpoint("restcomm/mock/1", inbandMixer, outbandMixer, connections, mediaGroup);
+        final EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/mock/1", "127.0.0.1:2427");
+        final MgcpMixerEndpoint endpoint = new MgcpMixerEndpoint(endpointId, inbandMixer, outbandMixer, connections, mediaGroup);
 
         // when - half open connection
         when(connections.provideRemote()).thenReturn(connection);

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpointProviderTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpointProviderTest.java
@@ -41,10 +41,11 @@ public class MgcpSplitterEndpointProviderTest {
     public void testProvide() {
         // given
         final String namespace = "ms/mock/";
+        final String domain = "restcomm.com";
         final PriorityQueueScheduler mediaScheduler = mock(PriorityQueueScheduler.class);
         final MgcpConnectionProvider connections = mock(MgcpConnectionProvider.class);
         final MediaGroupProvider mediaGroupProvider = mock(MediaGroupProvider.class);
-        final MgcpSplitterEndpointProvider provider = new MgcpSplitterEndpointProvider(namespace, mediaScheduler, connections, mediaGroupProvider);
+        final MgcpSplitterEndpointProvider provider = new MgcpSplitterEndpointProvider(namespace, domain, mediaScheduler, connections, mediaGroupProvider);
 
         // when
         MgcpSplitterEndpoint endpoint1 = provider.provide();
@@ -52,11 +53,11 @@ public class MgcpSplitterEndpointProviderTest {
         MgcpSplitterEndpoint endpoint3 = provider.provide();
 
         // then
-        assertEquals(namespace + 1, endpoint1.getEndpointId());
+        assertEquals(namespace + 1 + "@" + domain, endpoint1.getEndpointId().toString());
         assertFalse(endpoint1.isActive());
-        assertEquals(namespace + 2, endpoint2.getEndpointId());
+        assertEquals(namespace + 2 + "@" + domain, endpoint2.getEndpointId().toString());
         assertFalse(endpoint2.isActive());
-        assertEquals(namespace + 3, endpoint3.getEndpointId());
+        assertEquals(namespace + 3 + "@" + domain, endpoint3.getEndpointId().toString());
         assertFalse(endpoint3.isActive());
     }
 

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpointTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MgcpSplitterEndpointTest.java
@@ -56,7 +56,8 @@ public class MgcpSplitterEndpointTest {
         final OOBSplitter outbandMixer = mock(OOBSplitter.class);
         final MgcpConnectionProvider connections = mock(MgcpConnectionProvider.class);
         final MediaGroup mediaGroup = mock(MediaGroup.class);
-        final MgcpSplitterEndpoint endpoint = new MgcpSplitterEndpoint("restcomm/mock/1", inbandMixer, outbandMixer, connections, mediaGroup);
+        final EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/mock/1", "127.0.0.1");
+        final MgcpSplitterEndpoint endpoint = new MgcpSplitterEndpoint(endpointId, inbandMixer, outbandMixer, connections, mediaGroup);
 
         // when - half open connection
         when(connections.provideRemote()).thenReturn(connection);
@@ -85,7 +86,8 @@ public class MgcpSplitterEndpointTest {
         final OOBSplitter outbandSplitter = mock(OOBSplitter.class);
         final MgcpConnectionProvider connections = mock(MgcpConnectionProvider.class);
         final MediaGroup mediaGroup = mock(MediaGroup.class);
-        final MgcpSplitterEndpoint endpoint = new MgcpSplitterEndpoint("restcomm/mock/1", inbandSplitter, outbandSplitter, connections, mediaGroup);
+        final EndpointIdentifier endpointId = new EndpointIdentifier("mobicents/mock/1", "127.0.0.1");
+        final MgcpSplitterEndpoint endpoint = new MgcpSplitterEndpoint(endpointId, inbandSplitter, outbandSplitter, connections, mediaGroup);
 
         // when - open connection and join it to secondary endpoint
         when(connections.provideLocal()).thenReturn(connection);

--- a/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MixerEndpointProviderTest.java
+++ b/controls/mgcp2/src/test/java/org/mobicents/media/control/mgcp/endpoint/MixerEndpointProviderTest.java
@@ -42,10 +42,11 @@ public class MixerEndpointProviderTest {
     public void testProvide() {
         // given
         final String namespace = "ms/mock/";
+        final String domain = "restcomm.com";
         final PriorityQueueScheduler mediaScheduler = mock(PriorityQueueScheduler.class);
         final MgcpConnectionProvider connections = mock(MgcpConnectionProvider.class);
         final MediaGroupProvider mediaGroupProvider = mock(MediaGroupProvider.class);
-        final MgcpMixerEndpointProvider provider = new MgcpMixerEndpointProvider(namespace, mediaScheduler, connections, mediaGroupProvider);
+        final MgcpMixerEndpointProvider provider = new MgcpMixerEndpointProvider(namespace, domain, mediaScheduler, connections, mediaGroupProvider);
         final MediaGroupImpl mediaGroup = mock(MediaGroupImpl.class);
         final AudioComponent audioComponent = mock(AudioComponent.class);
 
@@ -58,11 +59,11 @@ public class MixerEndpointProviderTest {
         MgcpMixerEndpoint endpoint3 = provider.provide();
 
         // then
-        assertEquals(namespace + 1, endpoint1.getEndpointId());
+        assertEquals(namespace + 1 + "@" + domain, endpoint1.getEndpointId().toString());
         assertFalse(endpoint1.isActive());
-        assertEquals(namespace + 2, endpoint2.getEndpointId());
+        assertEquals(namespace + 2 + "@" + domain, endpoint2.getEndpointId().toString());
         assertFalse(endpoint2.isActive());
-        assertEquals(namespace + 3, endpoint3.getEndpointId());
+        assertEquals(namespace + 3 + "@" + domain, endpoint3.getEndpointId().toString());
         assertFalse(endpoint3.isActive());
     }
 


### PR DESCRIPTION
MgcpEndpoint now uses a EndpointName that contains both local name and domain, instead of a single String.

MgcpEndpointProvider now receive the Media Gateway domain to be able to create MgcpEndpoint.

Patched MGCP commands to reflect changes. CRCX now uses fully qualified identifier to register endpoints (instead of local name only).

MgcpResponse and MgcpRequest no longer hard code the domain.

Endpoint ID generator now wraps back to zero when reaches Integer.MAX_VALUE

Fixed testsuite.