### PR TITLE
Fixes #229 - Sdp answer only contains actually configured codecs

### DIFF
--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/ChannelsManagerProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/ChannelsManagerProvider.java
@@ -51,6 +51,7 @@ public class ChannelsManagerProvider implements Provider<ChannelsManager> {
         ChannelsManager channelsManager = new ChannelsManager(this.udpManager);
         channelsManager.setScheduler(mediaScheduler);
         channelsManager.setJitterBufferSize(config.getMediaConfiguration().getJitterBufferSize());
+        channelsManager.setCodecs(config.getMediaConfiguration().getCodecs());
         return channelsManager;
     }
 

--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DspProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DspProvider.java
@@ -21,8 +21,6 @@
         
 package org.mobicents.media.server.bootstrap.ioc.provider;
 
-import java.util.Iterator;
-
 import org.mobicents.media.core.configuration.CodecType;
 import org.mobicents.media.core.configuration.MediaServerConfiguration;
 import org.mobicents.media.server.component.DspFactoryImpl;
@@ -46,9 +44,9 @@ public class DspProvider implements Provider<DspFactoryImpl> {
     @Override
     public DspFactoryImpl get() {
         DspFactoryImpl dsp = new DspFactoryImpl();
-        Iterator<String> codecs = this.config.getMediaConfiguration().getCodecs();
-        while (codecs.hasNext()) {
-            CodecType codec = CodecType.fromName(codecs.next());
+        String[] codecs = this.config.getMediaConfiguration().getCodecs();
+        for(String c : codecs) {
+        	CodecType codec = CodecType.fromName(c);
             if(codec != null) {
                 dsp.addCodec(codec.getDecoder());
                 dsp.addCodec(codec.getEncoder());

--- a/bootstrap/src/test/java/org/mobicents/media/server/test/RecordingTest.java
+++ b/bootstrap/src/test/java/org/mobicents/media/server/test/RecordingTest.java
@@ -96,6 +96,7 @@ public class RecordingTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(scheduler);
         
         resourcesPool=new ResourcesPool(null, null, null, null, null, null, null, null);

--- a/bootstrap/src/test/java/org/mobicents/media/server/test/RelayTest.java
+++ b/bootstrap/src/test/java/org/mobicents/media/server/test/RelayTest.java
@@ -101,6 +101,7 @@ public class RelayTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(scheduler);
         
         resourcesPool=new ResourcesPool(null, null, null, null, null, null, null, null);

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/LocalMediaGroupTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/LocalMediaGroupTest.java
@@ -131,6 +131,7 @@ public class LocalMediaGroupTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         dspFactory.addCodec("org.mobicents.media.server.impl.dsp.audio.g711.alaw.Encoder");

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/MediaGroupTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/MediaGroupTest.java
@@ -130,6 +130,7 @@ public class MediaGroupTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         dspFactory.addCodec("org.mobicents.media.server.impl.dsp.audio.g711.alaw.Encoder");

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSMTest1.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSMTest1.java
@@ -115,6 +115,7 @@ public class BaseConnectionFSMTest1 {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSM_FR_Test.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSM_FR_Test.java
@@ -120,6 +120,7 @@ public class BaseConnectionFSM_FR_Test {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionTest.java
@@ -119,6 +119,7 @@ public class BaseConnectionTest implements ConnectionListener {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalConnectionImplTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalConnectionImplTest.java
@@ -107,6 +107,7 @@ public class LocalConnectionImplTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalJoiningTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalJoiningTest.java
@@ -119,6 +119,7 @@ public class LocalJoiningTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RTPEnvironment.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RTPEnvironment.java
@@ -66,6 +66,7 @@ public class RTPEnvironment {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
     }
     

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/ReclaimingTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/ReclaimingTest.java
@@ -109,6 +109,7 @@ public class ReclaimingTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionImplTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionImplTest.java
@@ -110,6 +110,7 @@ public class RtpConnectionImplTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionPoolTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionPoolTest.java
@@ -56,6 +56,7 @@ public class RtpConnectionPoolTest {
         this.taskScheduler = new ServiceScheduler(clock);
         this.udpManager = new UdpManager(taskScheduler);
         this.connectionFactory = new ChannelsManager(udpManager);
+        this.connectionFactory.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         this.dspFactory = new DspFactoryImpl();
         
         this.mediaScheduler.setClock(clock);

--- a/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
+++ b/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
@@ -107,7 +107,7 @@ public class MediaConfiguration {
     }
 
     public String[] getCodecs() {
-        return this.codecs.toArray(new String[]{});
+        return this.codecs.toArray(new String[codecs.size()]);
     }
     
     public boolean hasCodec(String codec) {

--- a/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
+++ b/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
@@ -22,7 +22,6 @@
 package org.mobicents.media.core.configuration;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -107,8 +106,8 @@ public class MediaConfiguration {
         this.codecs.add(codec.toLowerCase());
     }
 
-    public Iterator<String> getCodecs() {
-        return this.codecs.iterator();
+    public String[] getCodecs() {
+        return this.codecs.toArray(new String[]{});
     }
     
     public boolean hasCodec(String codec) {

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
@@ -23,6 +23,7 @@
 package org.mobicents.media.server.impl.rtp;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mobicents.media.server.impl.rtcp.RtcpChannel;
@@ -56,6 +57,9 @@ public class ChannelsManager {
     private PriorityQueueScheduler scheduler;
     
     private int jitterBufferSize=50;
+    
+    //Supported Formats --> It contains only codecs actually configured
+    private Iterator<String> codecs;
     
     //channel id generator
     private AtomicInteger channelIndex = new AtomicInteger(100);
@@ -111,6 +115,14 @@ public class ChannelsManager {
     public void setJitterBufferSize(int jitterBufferSize) {
     	this.jitterBufferSize=jitterBufferSize;
     }        
+    
+    public Iterator<String> getCodecs() {
+		return codecs;
+	}
+    
+    public void setCodecs(Iterator<String> iterator) {
+    	this.codecs = iterator;
+    }
     
     public UdpManager getUdpManager() {
     	return this.udpManager;

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
@@ -23,7 +23,6 @@
 package org.mobicents.media.server.impl.rtp;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mobicents.media.server.impl.rtcp.RtcpChannel;
@@ -59,7 +58,7 @@ public class ChannelsManager {
     private int jitterBufferSize=50;
     
     //Supported Formats --> It contains only codecs actually configured
-    private Iterator<String> codecs;
+    private String[] codecs;
     
     //channel id generator
     private AtomicInteger channelIndex = new AtomicInteger(100);
@@ -116,12 +115,12 @@ public class ChannelsManager {
     	this.jitterBufferSize=jitterBufferSize;
     }        
     
-    public Iterator<String> getCodecs() {
+    public String[] getCodecs() {
 		return codecs;
 	}
     
-    public void setCodecs(Iterator<String> iterator) {
-    	this.codecs = iterator;
+    public void setCodecs(String[] strings) {
+    	this.codecs = strings;
     }
     
     public UdpManager getUdpManager() {

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
@@ -20,11 +20,15 @@
 
 package org.mobicents.media.server.impl.rtp.channels;
 
+import java.util.Iterator;
+
 import org.mobicents.media.server.component.audio.AudioComponent;
 import org.mobicents.media.server.component.oob.OOBComponent;
 import org.mobicents.media.server.impl.rtp.ChannelsManager;
-import org.mobicents.media.server.io.sdp.format.AVProfile;
+import org.mobicents.media.server.io.sdp.format.RTPFormat;
+import org.mobicents.media.server.io.sdp.format.RTPFormats;
 import org.mobicents.media.server.scheduler.Clock;
+import org.mobicents.media.server.spi.format.FormatFactory;
 
 /**
  * Media channel responsible for audio processing.
@@ -39,7 +43,59 @@ public class AudioChannel extends MediaChannel {
 	public AudioChannel(Clock wallClock, ChannelsManager channelsManager) {
 		super(MEDIA_TYPE, wallClock, channelsManager);
 //		super.supportedFormats = super.buildRTPMap(AVProfile.audio);
-		super.supportedFormats = AVProfile.audio;
+		//super.supportedFormats = AVProfile.audio;
+		this.supportedFormats = new RTPFormats();
+		Iterator<String> codecs = channelsManager.getCodecs();
+		while(codecs.hasNext()) {
+			
+			switch (codecs.next()) {
+			case "pcmu":
+				RTPFormat pcmu = new RTPFormat(0, FormatFactory.createAudioFormat("pcmu", 8000, 8, 1), 8000);
+				supportedFormats.add(pcmu);
+				break;
+				
+			case "pcma":
+				RTPFormat pcma = new RTPFormat(8, FormatFactory.createAudioFormat("pcma", 8000, 8, 1), 8000);
+				supportedFormats.add(pcma);
+				break;
+				
+			case "gsm":
+				RTPFormat gsm = new RTPFormat(3, FormatFactory.createAudioFormat("gsm", 8000), 8000);
+				supportedFormats.add(gsm);
+				break;
+				
+			case "g729":
+				RTPFormat g729 = new RTPFormat(18, FormatFactory.createAudioFormat("g729", 8000), 8000);
+				supportedFormats.add(g729);
+				break;
+				
+			case "l16":
+				RTPFormat l16 = new RTPFormat(97, FormatFactory.createAudioFormat("l16", 8000, 16, 1), 8000);
+				supportedFormats.add(l16);
+				break;				
+				
+			case "ilbc":
+				RTPFormat ilbc = new RTPFormat(102, FormatFactory.createAudioFormat("ilbc", 8000, 16, 1), 8000);
+				supportedFormats.add(ilbc);
+				break;
+				
+			case "linear":
+				RTPFormat linear = new RTPFormat(150, FormatFactory.createAudioFormat("linear", 8000, 16, 1), 8000);
+				supportedFormats.add(linear);
+				break;
+
+			default:
+				break;
+			}
+			
+		}
+		
+		//Adding DTMF support
+		RTPFormat dtmf = new RTPFormat(101, FormatFactory.createAudioFormat("telephone-event", 8000), 8000);
+		supportedFormats.add(dtmf);
+		RTPFormat dtmf126 = new RTPFormat(126, FormatFactory.createAudioFormat("telephone-event", 8000), 8000);
+		supportedFormats.add(dtmf126);
+		
 		super.setFormats(this.supportedFormats);
 	}
 

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
@@ -20,15 +20,12 @@
 
 package org.mobicents.media.server.impl.rtp.channels;
 
-import java.util.Iterator;
-
 import org.mobicents.media.server.component.audio.AudioComponent;
 import org.mobicents.media.server.component.oob.OOBComponent;
 import org.mobicents.media.server.impl.rtp.ChannelsManager;
-import org.mobicents.media.server.io.sdp.format.RTPFormat;
+import org.mobicents.media.server.io.sdp.format.AVProfile;
 import org.mobicents.media.server.io.sdp.format.RTPFormats;
 import org.mobicents.media.server.scheduler.Clock;
-import org.mobicents.media.server.spi.format.FormatFactory;
 
 /**
  * Media channel responsible for audio processing.
@@ -43,45 +40,37 @@ public class AudioChannel extends MediaChannel {
 	public AudioChannel(Clock wallClock, ChannelsManager channelsManager) {
 		super(MEDIA_TYPE, wallClock, channelsManager);
 //		super.supportedFormats = super.buildRTPMap(AVProfile.audio);
-		//super.supportedFormats = AVProfile.audio;
 		this.supportedFormats = new RTPFormats();
-		Iterator<String> codecs = channelsManager.getCodecs();
-		while(codecs.hasNext()) {
+		String[] codecs = channelsManager.getCodecs();
+		for(String codec : codecs) {
 			
-			switch (codecs.next()) {
+			switch (codec) {
 			case "pcmu":
-				RTPFormat pcmu = new RTPFormat(0, FormatFactory.createAudioFormat("pcmu", 8000, 8, 1), 8000);
-				supportedFormats.add(pcmu);
+				supportedFormats.add(AVProfile.getFormat(0));
 				break;
 				
 			case "pcma":
-				RTPFormat pcma = new RTPFormat(8, FormatFactory.createAudioFormat("pcma", 8000, 8, 1), 8000);
-				supportedFormats.add(pcma);
+				supportedFormats.add(AVProfile.getFormat(8));
 				break;
 				
 			case "gsm":
-				RTPFormat gsm = new RTPFormat(3, FormatFactory.createAudioFormat("gsm", 8000), 8000);
-				supportedFormats.add(gsm);
+				supportedFormats.add(AVProfile.getFormat(8));
 				break;
 				
 			case "g729":
-				RTPFormat g729 = new RTPFormat(18, FormatFactory.createAudioFormat("g729", 8000), 8000);
-				supportedFormats.add(g729);
+				supportedFormats.add(AVProfile.getFormat(18));
 				break;
 				
 			case "l16":
-				RTPFormat l16 = new RTPFormat(97, FormatFactory.createAudioFormat("l16", 8000, 16, 1), 8000);
-				supportedFormats.add(l16);
+				supportedFormats.add(AVProfile.getFormat(97));
 				break;				
 				
 			case "ilbc":
-				RTPFormat ilbc = new RTPFormat(102, FormatFactory.createAudioFormat("ilbc", 8000, 16, 1), 8000);
-				supportedFormats.add(ilbc);
+				supportedFormats.add(AVProfile.getFormat(102));
 				break;
 				
 			case "linear":
-				RTPFormat linear = new RTPFormat(150, FormatFactory.createAudioFormat("linear", 8000, 16, 1), 8000);
-				supportedFormats.add(linear);
+				supportedFormats.add(AVProfile.getFormat(150));
 				break;
 
 			default:
@@ -91,10 +80,8 @@ public class AudioChannel extends MediaChannel {
 		}
 		
 		//Adding DTMF support
-		RTPFormat dtmf = new RTPFormat(101, FormatFactory.createAudioFormat("telephone-event", 8000), 8000);
-		supportedFormats.add(dtmf);
-		RTPFormat dtmf126 = new RTPFormat(126, FormatFactory.createAudioFormat("telephone-event", 8000), 8000);
-		supportedFormats.add(dtmf126);
+		supportedFormats.add(AVProfile.getFormat(101));
+		supportedFormats.add(AVProfile.getFormat(126));
 		
 		super.setFormats(this.supportedFormats);
 	}

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
@@ -54,7 +54,7 @@ public class AudioChannel extends MediaChannel {
 				break;
 				
 			case "gsm":
-				supportedFormats.add(AVProfile.getFormat(8));
+				supportedFormats.add(AVProfile.getFormat(3));
 				break;
 				
 			case "g729":

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalChannelTest.java
@@ -87,6 +87,7 @@ public class LocalChannelTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalEventTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalEventTest.java
@@ -99,6 +99,7 @@ public class LocalEventTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         detector = new DetectorImpl("dtmf", mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPDataChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPDataChannelTest.java
@@ -120,6 +120,7 @@ public class RTPDataChannelTest {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPEventTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPEventTest.java
@@ -128,6 +128,7 @@ public class RTPEventTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         detector = new DetectorImpl("dtmf", mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RtpChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RtpChannelTest.java
@@ -119,6 +119,7 @@ public class RtpChannelTest {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
+        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/channels/MediaChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/channels/MediaChannelTest.java
@@ -63,6 +63,7 @@ public class MediaChannelTest {
 		this.scheduler = new ServiceScheduler();
 		this.udpManager = new UdpManager(scheduler);
 		this.channelsManager = new ChannelsManager(udpManager);
+		this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
 		this.channelsManager.setScheduler(this.mediaScheduler);
 		
 		this.factory = new ChannelFactory();


### PR DESCRIPTION
AudioChannel instance was created populating its supportedFormats variable with every possible codec. I modified that passing to ChannelManager only the iterator of actually configured codecs, so that AudioChannle Instance can be created initializing supportedFormats accordingly.