### PR TITLE
Added support for configuring dtmf Detector + RFC2833 only mode

### DIFF
--- a/bootstrap/src/main/config/mediaserver.xml
+++ b/bootstrap/src/main/config/mediaserver.xml
@@ -55,7 +55,7 @@
 		<remoteConnection poolSize="50" />
 		<player poolSize="50" />
 		<recorder poolSize="50" />
-		<dtmfDetector poolSize="50" dbi="-35" />
+		<dtmfDetector poolSize="50" dbi="-35" rfc2833Only="false" />
 		<dtmfGenerator poolSize="50" toneVolume="-20" toneDuration="80" />
 		<signalDetector poolSize="0" />
 		<signalGenerator poolSize="0" />

--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/configuration/XmlConfigurationLoader.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/configuration/XmlConfigurationLoader.java
@@ -132,6 +132,7 @@ public class XmlConfigurationLoader implements ConfigurationLoader {
         dst.setRecorderCount(src.getInt("recorder[@poolSize]", ResourcesConfiguration.RECORDER_COUNT));
         dst.setDtmfDetectorCount(src.getInt("dtmfDetector[@poolSize]", ResourcesConfiguration.DTMF_DETECTOR_COUNT));
         dst.setDtmfDetectorDbi(src.getInt("dtmfDetector[@dbi]", ResourcesConfiguration.DTMF_DETECTOR_DBI));
+        dst.setDtmfDetectorRFC2833Only(src.getBoolean("dtmfDetector[@rfc2833Only]", ResourcesConfiguration.RFC2833_ONLY));
         dst.setDtmfGeneratorCount(src.getInt("dtmfGenerator[@poolSize]", ResourcesConfiguration.DTMF_GENERATOR_COUNT));
         dst.setDtmfGeneratorToneVolume(src.getInt("dtmfGenerator[@toneVolume]", ResourcesConfiguration.DTMF_GENERATOR_TONE_VOLUME));
         dst.setDtmfGeneratorToneDuration(src.getInt("dtmfGenerator[@toneDuration]", ResourcesConfiguration.DTMF_GENERATOR_TONE_DURATION));

--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DtmfDetectorFactoryProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DtmfDetectorFactoryProvider.java
@@ -21,6 +21,7 @@
 
 package org.mobicents.media.server.bootstrap.ioc.provider;
 
+import org.mobicents.media.core.configuration.MediaServerConfiguration;
 import org.mobicents.media.server.impl.resource.dtmf.DetectorImpl;
 import org.mobicents.media.server.impl.resource.dtmf.DtmfDetectorFactory;
 import org.mobicents.media.server.scheduler.PriorityQueueScheduler;
@@ -32,20 +33,24 @@ import com.google.inject.TypeLiteral;
 
 /**
  * @author Henrique Rosa (henrique.rosa@telestax.com)
- *
+ * @author Pavel Chlupacek (pavel.chlupacek@spinoco.com)
  */
 public class DtmfDetectorFactoryProvider implements Provider<DtmfDetectorFactory> {
 
+    private final MediaServerConfiguration config;
     private final PriorityQueueScheduler mediaScheduler;
 
     @Inject
-    public DtmfDetectorFactoryProvider(PriorityQueueScheduler mediaScheduler) {
+    public DtmfDetectorFactoryProvider(MediaServerConfiguration config, PriorityQueueScheduler mediaScheduler) {
+        this.config = config;
         this.mediaScheduler = mediaScheduler;
     }
 
     @Override
     public DtmfDetectorFactory get() {
-        return new DtmfDetectorFactory(this.mediaScheduler);
+        int volume = config.getResourcesConfiguration().getDtmfDetectorDbi();
+        boolean rfc2833 = config.getResourcesConfiguration().isDtmfDetectorRFC2833Only();
+        return new DtmfDetectorFactory(this.mediaScheduler, volume, rfc2833);
     }
 
     public static final class DtmfDetectorFactoryType extends TypeLiteral<PooledObjectFactory<DetectorImpl>> {

--- a/core/src/main/java/org/mobicents/media/core/configuration/ResourcesConfiguration.java
+++ b/core/src/main/java/org/mobicents/media/core/configuration/ResourcesConfiguration.java
@@ -40,6 +40,7 @@ public class ResourcesConfiguration {
     public static final int DTMF_GENERATOR_TONE_DURATION = 80;
     public static final int SIGNAL_DETECTOR_COUNT = 0;
     public static final int SIGNAL_GENERATOR_COUNT = 0;
+    public static final boolean RFC2833_ONLY = false;
 
     private int localConnectionCount;
     private int remoteConnectionCount;
@@ -47,6 +48,7 @@ public class ResourcesConfiguration {
     private int recorderCount;
     private int dtmfDetectorCount;
     private int dtmfDetectorDbi;
+    private boolean dtmfDetectorRFC2833Only;
     private int dtmfGeneratorCount;
     private int dtmfGeneratorToneVolume;
     private int dtmfGeneratorToneDuration;
@@ -131,6 +133,14 @@ public class ResourcesConfiguration {
             throw new IllegalArgumentException("DTMF Detector Dbi must be negative and greater than -36");
         }
         this.dtmfDetectorDbi = dtmfDetectorDbi;
+    }
+
+    public boolean isDtmfDetectorRFC2833Only() {
+        return dtmfDetectorRFC2833Only;
+    }
+
+    public void setDtmfDetectorRFC2833Only(boolean dtmfDetectorRFC2833Only) {
+        this.dtmfDetectorRFC2833Only = dtmfDetectorRFC2833Only;
     }
 
     public int getDtmfGeneratorCount() {

--- a/resources/telephony/dtmf/src/main/java/org/mobicents/media/server/impl/resource/dtmf/DtmfDetectorFactory.java
+++ b/resources/telephony/dtmf/src/main/java/org/mobicents/media/server/impl/resource/dtmf/DtmfDetectorFactory.java
@@ -41,10 +41,12 @@ public class DtmfDetectorFactory implements PooledObjectFactory<DetectorImpl> {
 
     private final PriorityQueueScheduler mediaScheduler;
     private int volume;
+    private boolean rfc2833Only;
 
-    public DtmfDetectorFactory(PriorityQueueScheduler mediaScheduler, int volume) {
+    public DtmfDetectorFactory(PriorityQueueScheduler mediaScheduler, int volume, boolean rfc2833Only) {
         this.mediaScheduler = mediaScheduler;
         this.volume = volume;
+        this.rfc2833Only = rfc2833Only;
     }
 
     public DtmfDetectorFactory(PriorityQueueScheduler mediaScheduler) {
@@ -56,6 +58,7 @@ public class DtmfDetectorFactory implements PooledObjectFactory<DetectorImpl> {
     public DetectorImpl produce() {
         DetectorImpl detector = new DetectorImpl("detector-" + ID.getAndIncrement(), mediaScheduler);
         detector.setVolume(this.volume);
+        detector.setRFC2833EventsOnly(this.rfc2833Only);
         return detector;
     }
 

--- a/spi/src/main/java/org/mobicents/media/server/spi/dtmf/DtmfDetector.java
+++ b/spi/src/main/java/org/mobicents/media/server/spi/dtmf/DtmfDetector.java
@@ -68,6 +68,17 @@ public interface DtmfDetector extends MediaSink {
      * @return the value in dBm0
      */
     public int getVolume();
+
+    /**
+     * Indicates, that the decoder will handle RFC2833 telephony events only.
+     * @param flag true to detect only telephony events, false otherwise
+     */
+    public void setRFC2833EventsOnly(boolean flag);
+
+    /**
+     * Returns true, if this detector detects RFC 2833 Events only, false otherwise.
+     */
+    public boolean getRFC2833EventsOnly();
     
     /**
      * Starts media processing.


### PR DESCRIPTION
@hrosa Found that dtmf detector is not using configuration in current RMS head, and added turn-off of in-band detection

Specifically on this RFC 2833 only mode can you take a look on it. Not sure If I did it correctly as the code flow is really hard to grasp, so essentially this only fixes my observation of telephone-event detection. 
