### PR TITLE
Revert "Fixes #229 - Sdp answer only contains actually configured codecs"

### DIFF
--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/ChannelsManagerProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/ChannelsManagerProvider.java
@@ -51,7 +51,6 @@ public class ChannelsManagerProvider implements Provider<ChannelsManager> {
         ChannelsManager channelsManager = new ChannelsManager(this.udpManager);
         channelsManager.setScheduler(mediaScheduler);
         channelsManager.setJitterBufferSize(config.getMediaConfiguration().getJitterBufferSize());
-        channelsManager.setCodecs(config.getMediaConfiguration().getCodecs());
         return channelsManager;
     }
 

--- a/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DspProvider.java
+++ b/bootstrap/src/main/java/org/mobicents/media/server/bootstrap/ioc/provider/DspProvider.java
@@ -21,6 +21,8 @@
         
 package org.mobicents.media.server.bootstrap.ioc.provider;
 
+import java.util.Iterator;
+
 import org.mobicents.media.core.configuration.CodecType;
 import org.mobicents.media.core.configuration.MediaServerConfiguration;
 import org.mobicents.media.server.component.DspFactoryImpl;
@@ -44,9 +46,9 @@ public class DspProvider implements Provider<DspFactoryImpl> {
     @Override
     public DspFactoryImpl get() {
         DspFactoryImpl dsp = new DspFactoryImpl();
-        String[] codecs = this.config.getMediaConfiguration().getCodecs();
-        for(String c : codecs) {
-        	CodecType codec = CodecType.fromName(c);
+        Iterator<String> codecs = this.config.getMediaConfiguration().getCodecs();
+        while (codecs.hasNext()) {
+            CodecType codec = CodecType.fromName(codecs.next());
             if(codec != null) {
                 dsp.addCodec(codec.getDecoder());
                 dsp.addCodec(codec.getEncoder());

--- a/bootstrap/src/test/java/org/mobicents/media/server/test/RecordingTest.java
+++ b/bootstrap/src/test/java/org/mobicents/media/server/test/RecordingTest.java
@@ -96,7 +96,6 @@ public class RecordingTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(scheduler);
         
         resourcesPool=new ResourcesPool(null, null, null, null, null, null, null, null);

--- a/bootstrap/src/test/java/org/mobicents/media/server/test/RelayTest.java
+++ b/bootstrap/src/test/java/org/mobicents/media/server/test/RelayTest.java
@@ -101,7 +101,6 @@ public class RelayTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(scheduler);
         
         resourcesPool=new ResourcesPool(null, null, null, null, null, null, null, null);

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/LocalMediaGroupTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/LocalMediaGroupTest.java
@@ -131,7 +131,6 @@ public class LocalMediaGroupTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         dspFactory.addCodec("org.mobicents.media.server.impl.dsp.audio.g711.alaw.Encoder");

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/MediaGroupTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/MediaGroupTest.java
@@ -130,7 +130,6 @@ public class MediaGroupTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         dspFactory.addCodec("org.mobicents.media.server.impl.dsp.audio.g711.alaw.Encoder");

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSMTest1.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSMTest1.java
@@ -115,7 +115,6 @@ public class BaseConnectionFSMTest1 {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSM_FR_Test.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionFSM_FR_Test.java
@@ -120,7 +120,6 @@ public class BaseConnectionFSM_FR_Test {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/BaseConnectionTest.java
@@ -119,7 +119,6 @@ public class BaseConnectionTest implements ConnectionListener {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalConnectionImplTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalConnectionImplTest.java
@@ -107,7 +107,6 @@ public class LocalConnectionImplTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalJoiningTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/LocalJoiningTest.java
@@ -119,7 +119,6 @@ public class LocalJoiningTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RTPEnvironment.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RTPEnvironment.java
@@ -66,7 +66,6 @@ public class RTPEnvironment {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
     }
     

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/ReclaimingTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/ReclaimingTest.java
@@ -109,7 +109,6 @@ public class ReclaimingTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionImplTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionImplTest.java
@@ -110,7 +110,6 @@ public class RtpConnectionImplTest {
         mediaScheduler.start();
 
         channelsManager = new ChannelsManager(new UdpManager(new ServiceScheduler()));
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);        
 
         // Resource

--- a/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionPoolTest.java
+++ b/controls/mgcp/src/test/java/org/mobicents/media/server/mgcp/endpoint/connection/RtpConnectionPoolTest.java
@@ -56,7 +56,6 @@ public class RtpConnectionPoolTest {
         this.taskScheduler = new ServiceScheduler(clock);
         this.udpManager = new UdpManager(taskScheduler);
         this.connectionFactory = new ChannelsManager(udpManager);
-        this.connectionFactory.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         this.dspFactory = new DspFactoryImpl();
         
         this.mediaScheduler.setClock(clock);

--- a/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
+++ b/core/src/main/java/org/mobicents/media/core/configuration/MediaConfiguration.java
@@ -22,6 +22,7 @@
 package org.mobicents.media.core.configuration;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -106,8 +107,8 @@ public class MediaConfiguration {
         this.codecs.add(codec.toLowerCase());
     }
 
-    public String[] getCodecs() {
-        return this.codecs.toArray(new String[codecs.size()]);
+    public Iterator<String> getCodecs() {
+        return this.codecs.iterator();
     }
     
     public boolean hasCodec(String codec) {

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/ChannelsManager.java
@@ -57,9 +57,6 @@ public class ChannelsManager {
     
     private int jitterBufferSize=50;
     
-    //Supported Formats --> It contains only codecs actually configured
-    private String[] codecs;
-    
     //channel id generator
     private AtomicInteger channelIndex = new AtomicInteger(100);
     
@@ -114,14 +111,6 @@ public class ChannelsManager {
     public void setJitterBufferSize(int jitterBufferSize) {
     	this.jitterBufferSize=jitterBufferSize;
     }        
-    
-    public String[] getCodecs() {
-		return codecs;
-	}
-    
-    public void setCodecs(String[] strings) {
-    	this.codecs = strings;
-    }
     
     public UdpManager getUdpManager() {
     	return this.udpManager;

--- a/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
+++ b/io/rtp/src/main/java/org/mobicents/media/server/impl/rtp/channels/AudioChannel.java
@@ -24,7 +24,6 @@ import org.mobicents.media.server.component.audio.AudioComponent;
 import org.mobicents.media.server.component.oob.OOBComponent;
 import org.mobicents.media.server.impl.rtp.ChannelsManager;
 import org.mobicents.media.server.io.sdp.format.AVProfile;
-import org.mobicents.media.server.io.sdp.format.RTPFormats;
 import org.mobicents.media.server.scheduler.Clock;
 
 /**
@@ -40,49 +39,7 @@ public class AudioChannel extends MediaChannel {
 	public AudioChannel(Clock wallClock, ChannelsManager channelsManager) {
 		super(MEDIA_TYPE, wallClock, channelsManager);
 //		super.supportedFormats = super.buildRTPMap(AVProfile.audio);
-		this.supportedFormats = new RTPFormats();
-		String[] codecs = channelsManager.getCodecs();
-		for(String codec : codecs) {
-			
-			switch (codec) {
-			case "pcmu":
-				supportedFormats.add(AVProfile.getFormat(0));
-				break;
-				
-			case "pcma":
-				supportedFormats.add(AVProfile.getFormat(8));
-				break;
-				
-			case "gsm":
-				supportedFormats.add(AVProfile.getFormat(3));
-				break;
-				
-			case "g729":
-				supportedFormats.add(AVProfile.getFormat(18));
-				break;
-				
-			case "l16":
-				supportedFormats.add(AVProfile.getFormat(97));
-				break;				
-				
-			case "ilbc":
-				supportedFormats.add(AVProfile.getFormat(102));
-				break;
-				
-			case "linear":
-				supportedFormats.add(AVProfile.getFormat(150));
-				break;
-
-			default:
-				break;
-			}
-			
-		}
-		
-		//Adding DTMF support
-		supportedFormats.add(AVProfile.getFormat(101));
-		supportedFormats.add(AVProfile.getFormat(126));
-		
+		super.supportedFormats = AVProfile.audio;
 		super.setFormats(this.supportedFormats);
 	}
 

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalChannelTest.java
@@ -87,7 +87,6 @@ public class LocalChannelTest {
         udpManager.start();
 
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalEventTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/LocalEventTest.java
@@ -99,7 +99,6 @@ public class LocalEventTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         detector = new DetectorImpl("dtmf", mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPDataChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPDataChannelTest.java
@@ -120,7 +120,6 @@ public class RTPDataChannelTest {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPEventTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RTPEventTest.java
@@ -128,7 +128,6 @@ public class RTPEventTest implements DtmfDetectorListener {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
         
         detector = new DetectorImpl("dtmf", mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RtpChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/RtpChannelTest.java
@@ -119,7 +119,6 @@ public class RtpChannelTest {
         udpManager.start();
         
         channelsManager = new ChannelsManager(udpManager);
-        this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
         channelsManager.setScheduler(mediaScheduler);
 
         source1 = new Sine(mediaScheduler);

--- a/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/channels/MediaChannelTest.java
+++ b/io/rtp/src/test/java/org/mobicents/media/server/impl/rtp/channels/MediaChannelTest.java
@@ -63,7 +63,6 @@ public class MediaChannelTest {
 		this.scheduler = new ServiceScheduler();
 		this.udpManager = new UdpManager(scheduler);
 		this.channelsManager = new ChannelsManager(udpManager);
-		this.channelsManager.setCodecs(new String[]{"pcmu", "pcma", "gsm", "g729"});
 		this.channelsManager.setScheduler(this.mediaScheduler);
 		
 		this.factory = new ChannelFactory();


### PR DESCRIPTION
Reverts RestComm/mediaserver#244 because testuite for MGCP was broken.