### PR TITLE
MGCP stack doesnt trigger reverse DNS lookups

### DIFF
--- a/controls/mgcp/src/main/java/org/mobicents/media/server/mgcp/MgcpProvider.java
+++ b/controls/mgcp/src/main/java/org/mobicents/media/server/mgcp/MgcpProvider.java
@@ -307,7 +307,7 @@ public class MgcpProvider extends MultiplexedChannel {
          */
         protected void setAddress(SocketAddress address) {
             InetSocketAddress a = (InetSocketAddress) address;
-            this.address = new InetSocketAddress(a.getHostName(), a.getPort());
+            this.address = new InetSocketAddress(a.getAddress().getHostAddress(), a.getPort());
         }
     }
 }


### PR DESCRIPTION
Mgcp stack uses literal IP address of remote peer and no longer tries to perform reverse DNS lookup.